### PR TITLE
Fix session_energy reset handling and rename to Session Energy

### DIFF
--- a/custom_components/wattpilot/sensor.py
+++ b/custom_components/wattpilot/sensor.py
@@ -159,9 +159,12 @@ class ChargerSensor(ChargerPlatformEntity, SensorEntity):
                 precision = self.entity_description.suggested_display_precision
                 if precision is not None:
                     state = round(state, precision)
-                # Never report a value lower than what was last stored.
+                # Prevent tiny floating-point noise from causing HA recorder warnings
+                # by enforcing monotonicity for small drops, but allow significant
+                # drops (>= 1.0) to pass through so true resets (e.g. new session) work.
                 if isinstance(self._attr_native_value, int | float):
-                    state = max(state, self._attr_native_value)
+                    if state < self._attr_native_value and (self._attr_native_value - state) < 1.0:
+                        state = self._attr_native_value
             if self._attr_native_unit_of_measurement is not None:
                 self._attr_native_value = state
             return state

--- a/custom_components/wattpilot/strings.json
+++ b/custom_components/wattpilot/strings.json
@@ -242,7 +242,7 @@
         "name": "WebSocket Clients"
       },
       "session_energy": {
-        "name": "Connection Charged"
+        "name": "Session Energy"
       },
       "wifi_state": {
         "name": "WiFi State"

--- a/custom_components/wattpilot/translations/en.json
+++ b/custom_components/wattpilot/translations/en.json
@@ -242,7 +242,7 @@
         "name": "WebSocket Clients"
       },
       "session_energy": {
-        "name": "Connection Charged"
+        "name": "Session Energy"
       },
       "wifi_state": {
         "name": "WiFi State"


### PR DESCRIPTION
Fixed "Connection Charged" reset logic.

Renamed to "Session Energy" in keeping with updated official Solar.WattPilot app.